### PR TITLE
Remove java dependencies

### DIFF
--- a/src/main/deb/control/control
+++ b/src/main/deb/control/control
@@ -3,5 +3,6 @@ Version: [[version]]
 Section: misc
 Priority: low
 Architecture: all
+Depends: 
 Description: [[description]]
 Maintainer: burton@spinn3r.com


### PR DESCRIPTION
It seems kibana is shipped with node.js. No need to put java dependencies (come from jdeb defaults)